### PR TITLE
fix: prevent shell injection in curl command (#2)

### DIFF
--- a/scripts/search.js
+++ b/scripts/search.js
@@ -84,6 +84,16 @@ function truncate(text, maxLength) {
 }
 
 /**
+ * Shell-escape a string for safe interpolation into shell commands.
+ * Wraps string in single quotes and escapes any embedded single quotes.
+ * @param {string} str - String to escape
+ * @returns {string} Shell-safe escaped string
+ */
+function shellEscape(str) {
+	return "'" + str.replace(/'/g, "'\\''") + "'";
+}
+
+/**
  * Perform HTTP GET request.
  * @param {string} url - URL to fetch
  * @param {number} timeoutSecs - Timeout in seconds
@@ -91,8 +101,10 @@ function truncate(text, maxLength) {
  */
 function httpGet(url, timeoutSecs) {
 	try {
-		// Simple curl request - JXA's doShellScript has issues with complex output parsing
-		const curlCmd = `curl --silent --location --max-time ${timeoutSecs} "${url}"`;
+		// Shell-escape URL to prevent command injection
+		// Use -- to prevent URLs starting with - from being interpreted as options
+		const escapedUrl = shellEscape(url);
+		const curlCmd = `curl --silent --location --max-time ${timeoutSecs} -- ${escapedUrl}`;
 		const response = app.doShellScript(curlCmd);
 
 		// Check for curl errors (when curl itself fails)


### PR DESCRIPTION
## Summary

- Add `shellEscape()` function that wraps strings in single quotes and escapes embedded single quotes
- Update `httpGet()` to use shell-escaped URLs
- Add `--` separator before URL to prevent option injection for URLs starting with `-`

## Changes

The vulnerable code:
```javascript
const curlCmd = `curl --silent --location --max-time ${timeoutSecs} "${url}"`;
```

Is now:
```javascript
const escapedUrl = shellEscape(url);
const curlCmd = `curl --silent --location --max-time ${timeoutSecs} -- ${escapedUrl}`;
```

## Test Plan

- [x] Normal URLs work unchanged
- [ ] URLs with single quotes are properly escaped
- [ ] URLs with `$`, backticks, and double quotes are safe
- [ ] URLs starting with `-` don't trigger curl options

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for URL handling in search operations by implementing enhanced escaping mechanisms that safely process special characters and URLs starting with a dash. This mitigates potential command injection vulnerabilities and ensures more reliable and secure search functionality across various URL formats and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->