### PR TITLE
feat: display website favicons for search results (#4)

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -200,6 +200,19 @@
        - html
        - json
 
+### Favicons (Optional)
+
+To display website favicons in search results:
+
+1. Enable favicon support in your SearXNG settings.yml:
+
+   search:
+     favicon_resolver: "duckduckgo"
+
+2. Copy your secret_key from settings.yml (server.secret_key) into the workflow configuration
+
+Favicons are fetched through your own SearXNG instance's favicon proxy, preserving privacy.
+
 ## Usage
 
 - Type `sx` followed by your search query
@@ -291,6 +304,27 @@
 			<string>textfield</string>
 			<key>variable</key>
 			<string>timeout_ms</string>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>default</key>
+				<string></string>
+				<key>placeholder</key>
+				<string>ultrasecretkey</string>
+				<key>required</key>
+				<false/>
+				<key>trim</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string>Secret key from your SearXNG settings.yml (server.secret_key). Required to display website favicons via SearXNG's favicon proxy. Leave empty to disable favicons.</string>
+			<key>label</key>
+			<string>Secret Key (for favicons)</string>
+			<key>type</key>
+			<string>textfield</string>
+			<key>variable</key>
+			<string>secret_key</string>
 		</dict>
 	</array>
 	<key>version</key>


### PR DESCRIPTION
## Summary

- Add favicon caching system that fetches and displays website favicons next to search results
- **Privacy-first**: Uses SearXNG's native favicon proxy instead of external services
- Requires user's SearXNG `secret_key` for HMAC authentication
- Cache favicons locally in Alfred's workflow data directory for fast subsequent loads
- Use NSFileManager for efficient file existence checks (avoids shell overhead)
- Memoize directory paths to minimize shell calls
- Limit to 3 new favicon fetches per search to maintain UI responsiveness
- Graceful fallback to generic icon when secret_key not configured or on fetch failure

## Configuration

New workflow setting: **Secret Key (for favicons)**

To enable favicons:
1. Enable favicon support in your SearXNG `settings.yml`:
   ```yaml
   search:
     favicon_resolver: "duckduckgo"  # or allesedv, google, yandex
   ```
2. Copy `server.secret_key` from your SearXNG settings into the workflow configuration

Leave empty to disable favicons (graceful fallback to generic icon).

## Technical Details

**Privacy Model:**
- All favicon requests route through user's own SearXNG instance
- SearXNG's cache reduces external requests
- User controls which resolver their SearXNG uses
- No direct requests to external favicon services from Alfred

**HMAC Authentication:**
- Computes HMAC-SHA256 matching SearXNG's `new_hmac()` function
- Uses `openssl dgst` (available on all macOS)
- URL format: `{searxng_url}/favicon_proxy?authority={domain}&h={hmac}`

**Cache Location:**
```
~/Library/Application Support/Alfred/Workflow Data/com.ggfevans.alfred-searxng/favicons/
```

**Performance Optimizations:**
- Memoized directory paths (only computed once)
- NSFileManager for file checks instead of shell `test -f`
- 1-second timeout on favicon fetch to keep UI snappy
- Max 3 new fetches per search (cached domains are unlimited)

## Test Plan

- [x] Existing unit tests pass
- [ ] Manual: Configure secret_key from SearXNG settings.yml
- [ ] Manual: Search shows favicons for popular domains (github.com, stackoverflow.com)
- [ ] Manual: Cache directory is created with favicon files
- [ ] Manual: Subsequent searches load cached favicons instantly
- [ ] Manual: Search remains responsive on first load (max 3 new fetches)
- [ ] Manual: Without secret_key, generic icon shown (no errors)

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional favicon display for search results with on-disk caching, per-search fetch throttling, and a generic-icon fallback.

* **Configuration**
  * Added "Secret Key (for favicons)" setting to enable favicon proxy integration.

* **Documentation**
  * README updated with instructions to enable favicon proxy and configure the secret key.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->