### PR TITLE
feat: add Fallback Search trigger for default web search replacement

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -8,6 +8,29 @@
 	<string>Internet</string>
 	<key>connections</key>
 	<dict>
+		<key>A597C019-17C0-4EFC-8209-C78914AB31B3</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>110802D2-8EA0-42A2-9E3F-EF61E70504E7</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitowards</key>
+				<string></string>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>0220E219-39E7-431D-A3D4-D3AB3583A16B</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitowards</key>
+				<string>right</string>
+			</dict>
+		</array>
 		<key>A7087C90-0C31-4269-983C-868379879BA7</key>
 		<array>
 			<dict>
@@ -41,27 +64,17 @@
 				<string></string>
 			</dict>
 		</array>
-		<key>A597C019-17C0-4EFC-8209-C78914AB31B3</key>
+		<key>B8F3D2A1-5E4C-4B9A-8D7F-1A2B3C4D5E6F</key>
 		<array>
 			<dict>
 				<key>destinationuid</key>
-				<string>110802D2-8EA0-42A2-9E3F-EF61E70504E7</string>
+				<string>A90F3B4C-C814-4CF0-9010-78FA06412154</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
 				<string></string>
 				<key>vitowards</key>
 				<string></string>
-			</dict>
-			<dict>
-				<key>destinationuid</key>
-				<string>0220E219-39E7-431D-A3D4-D3AB3583A16B</string>
-				<key>modifiers</key>
-				<integer>0</integer>
-				<key>modifiersubtext</key>
-				<string></string>
-				<key>vitowards</key>
-				<string>right</string>
 			</dict>
 		</array>
 	</dict>
@@ -186,6 +199,36 @@
 			<key>version</key>
 			<integer>3</integer>
 		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>text</key>
+				<string>Search SearXNG</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.trigger.fallback</string>
+			<key>uid</key>
+			<string>B8F3D2A1-5E4C-4B9A-8D7F-1A2B3C4D5E6F</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>browser</key>
+				<string></string>
+				<key>spaces</key>
+				<string></string>
+				<key>url</key>
+				<string>{var:searxng_url}/search?q={query}</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.openurl</string>
+			<key>uid</key>
+			<string>A90F3B4C-C814-4CF0-9010-78FA06412154</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
 	</array>
 	<key>readme</key>
 	<string>Search your personal SearXNG instance directly from Alfred.
@@ -213,9 +256,21 @@ To display website favicons in search results:
 
 Favicons are fetched through your own SearXNG instance's favicon proxy, preserving privacy.
 
+### Replace Default Web Search (Optional)
+
+To use SearXNG as your default fallback search (instead of Google):
+
+1. Open Alfred Preferences → Features → Default Results
+2. Click "Setup fallback results" at the bottom
+3. Click + and find "Search SearXNG" under this workflow
+4. Drag it to the top of the list (or remove Google)
+
+Now when you type anything and press Enter, it searches SearXNG!
+
 ## Usage
 
-- Type `sx` followed by your search query
+- Type `sx` followed by your search query (shows results in Alfred)
+- Or use as fallback search (opens SearXNG in browser)
 - Press Enter to open the result in your browser
 - Press Cmd to copy the URL
 - Press Option to open the search in SearXNG web interface
@@ -232,33 +287,47 @@ Favicons are fetched through your own SearXNG instance's favicon proxy, preservi
 </string>
 	<key>uidata</key>
 	<dict>
-		<key>A7087C90-0C31-4269-983C-868379879BA7</key>
+		<key>0220E219-39E7-431D-A3D4-D3AB3583A16B</key>
 		<dict>
 			<key>xpos</key>
-			<real>50</real>
+			<real>490.0</real>
 			<key>ypos</key>
-			<real>50</real>
-		</dict>
-		<key>A597C019-17C0-4EFC-8209-C78914AB31B3</key>
-		<dict>
-			<key>xpos</key>
-			<real>270</real>
-			<key>ypos</key>
-			<real>50</real>
+			<real>170.0</real>
 		</dict>
 		<key>110802D2-8EA0-42A2-9E3F-EF61E70504E7</key>
 		<dict>
 			<key>xpos</key>
-			<real>490</real>
+			<real>490.0</real>
 			<key>ypos</key>
-			<real>50</real>
+			<real>50.0</real>
 		</dict>
-		<key>0220E219-39E7-431D-A3D4-D3AB3583A16B</key>
+		<key>A597C019-17C0-4EFC-8209-C78914AB31B3</key>
 		<dict>
 			<key>xpos</key>
-			<real>490</real>
+			<real>270.0</real>
 			<key>ypos</key>
-			<real>170</real>
+			<real>50.0</real>
+		</dict>
+		<key>A7087C90-0C31-4269-983C-868379879BA7</key>
+		<dict>
+			<key>xpos</key>
+			<real>50.0</real>
+			<key>ypos</key>
+			<real>50.0</real>
+		</dict>
+		<key>B8F3D2A1-5E4C-4B9A-8D7F-1A2B3C4D5E6F</key>
+		<dict>
+			<key>xpos</key>
+			<real>50.0</real>
+			<key>ypos</key>
+			<real>250.0</real>
+		</dict>
+		<key>A90F3B4C-C814-4CF0-9010-78FA06412154</key>
+		<dict>
+			<key>xpos</key>
+			<real>270.0</real>
+			<key>ypos</key>
+			<real>250.0</real>
 		</dict>
 	</dict>
 	<key>userconfigurationconfig</key>


### PR DESCRIPTION
## Summary
- Adds a Fallback Search trigger to replace Google as default web search
- When enabled, typing anything in Alfred and pressing Enter searches SearXNG
- Opens SearXNG's web UI directly (fast, no script execution)

## Setup
1. Open Alfred Preferences → Features → Default Results
2. Click "Setup fallback results" at the bottom
3. Click + and find "Search SearXNG" under this workflow
4. Drag to top of list (or remove Google entirely)

## How it differs from `sx` keyword
| Feature | `sx` keyword | Fallback |
|---------|-------------|----------|
| Shows results in Alfred | ✓ | ✗ |
| Instant (no network wait) | ✗ | ✓ |
| Requires prefix | ✓ (`sx `) | ✗ |
| Opens browser | After selection | Immediately |

## Test plan
- [x] Add fallback trigger to workflow
- [ ] Verify appears in Alfred's fallback setup
- [ ] Test searching with fallback enabled
- [ ] Verify URL includes query parameter correctly

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new SearXNG fallback search trigger with customizable keyboard shortcut support
  * Introduced optional default web search configuration allowing users to set SearXNG as their preferred search engine

* **Documentation**
  * Updated user guide with instructions for configuring the fallback search feature and managing search order preferences in Alfred

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->