### PR TITLE
chore: add postversion hook to sync versions (#25)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "alfred-searxng-workflow",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "description": "Alfred workflow for searching with SearXNG",
   "scripts": {
-    "test": "node --test tests/*.test.js"
+    "test": "node --test tests/*.test.js",
+    "postversion": "node scripts/sync-version.js && git add info.plist"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/**
+ * Sync version from package.json to info.plist
+ *
+ * Called automatically by npm's postversion hook to ensure
+ * both files stay in sync after version bumps.
+ */
+
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+// Semver pattern (strict)
+const SEMVER_PATTERN = /^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?$/;
+
+// Read version from package.json
+const pkg = require('../package.json');
+const version = pkg.version;
+
+// Validate version format to prevent injection
+if (!SEMVER_PATTERN.test(version)) {
+  console.error(`Invalid version format: ${version}`);
+  console.error('Version must match semver pattern (e.g., 1.0.0 or 1.0.0-beta.1)');
+  process.exit(1);
+}
+
+// Path to info.plist (relative to project root)
+const plistPath = path.join(__dirname, '..', 'info.plist');
+
+// Update info.plist using PlistBuddy (execFileSync avoids shell interpolation)
+try {
+  execFileSync('/usr/libexec/PlistBuddy', ['-c', `Set :version ${version}`, plistPath], {
+    stdio: 'inherit'
+  });
+  console.log(`Synced version ${version} to info.plist`);
+} catch (error) {
+  console.error('Failed to sync version to info.plist:', error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- Add `scripts/sync-version.js` to automatically update info.plist when `npm version` is run
- Add `postversion` npm hook to trigger sync and stage info.plist
- Update package.json version from 0.1.0 to 1.0.0 to match info.plist

## How It Works

After this PR, version bumping becomes:
```bash
npm version patch  # or minor/major
# Automatically: updates both files, stages info.plist
git push && git push --tags
```

## Security

- Uses `execFileSync` instead of `execSync` to avoid shell interpolation
- Validates version against strict semver pattern before use

## Test Plan

- [ ] Run `node scripts/sync-version.js` - should print "Synced version 1.0.0 to info.plist"
- [ ] Verify both files show same version: `grep version package.json` and `/usr/libexec/PlistBuddy -c "Print :version" info.plist`

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 1.0.0 of the project.
  * Enhanced version management infrastructure to ensure consistency across project files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->