### PR TITLE
fix: normalize HMAC output for cross-platform compatibility (#23)

### DIFF
--- a/tests/hmac.test.js
+++ b/tests/hmac.test.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for HMAC output normalization
+ * Run with: node tests/hmac.test.js
+ */
+
+const assert = require("node:assert");
+const { describe, it } = require("node:test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+// Extract normalizeHmacOutput function from search.js
+const searchJs = fs.readFileSync(
+	path.join(__dirname, "../scripts/search.js"),
+	"utf-8"
+);
+const normalizeHmacMatch = searchJs.match(
+	/function normalizeHmacOutput\(output\) \{[\s\S]*?return trimmed;\s*\}/
+);
+if (!normalizeHmacMatch) {
+	throw new Error("Could not find normalizeHmacOutput function in search.js");
+}
+// eslint-disable-next-line no-eval
+const normalizeHmacOutput = eval(`(${normalizeHmacMatch[0]})`);
+
+describe("normalizeHmacOutput", () => {
+	const expectedHash = "6afeb25a205f6b540cf4efa6a20d12b5e8a3c1d7f9e0b2a4c6d8e0f1a3b5c7d9";
+
+	it("handles macOS LibreSSL format (hash only)", () => {
+		const result = normalizeHmacOutput(expectedHash);
+		assert.strictEqual(result, expectedHash);
+	});
+
+	it("handles macOS LibreSSL format with whitespace", () => {
+		const result = normalizeHmacOutput(`  ${expectedHash}  \n`);
+		assert.strictEqual(result, expectedHash);
+	});
+
+	it("handles OpenSSL SHA2-256 prefixed format", () => {
+		const result = normalizeHmacOutput(`SHA2-256(stdin)= ${expectedHash}`);
+		assert.strictEqual(result, expectedHash);
+	});
+
+	it("handles OpenSSL HMAC-SHA256 prefixed format", () => {
+		const result = normalizeHmacOutput(`HMAC-SHA256(stdin)= ${expectedHash}`);
+		assert.strictEqual(result, expectedHash);
+	});
+
+	it("handles generic openssl dgst format", () => {
+		const result = normalizeHmacOutput(`(stdin)= ${expectedHash}`);
+		assert.strictEqual(result, expectedHash);
+	});
+
+	it("handles prefixed format with trailing whitespace", () => {
+		const result = normalizeHmacOutput(`SHA2-256(stdin)= ${expectedHash}  \n`);
+		assert.strictEqual(result, expectedHash);
+	});
+
+	it("handles prefixed format with leading whitespace", () => {
+		const result = normalizeHmacOutput(`  SHA2-256(stdin)= ${expectedHash}`);
+		assert.strictEqual(result, expectedHash);
+	});
+
+	it("handles empty string gracefully", () => {
+		const result = normalizeHmacOutput("");
+		assert.strictEqual(result, "");
+	});
+
+	it("handles whitespace-only string", () => {
+		const result = normalizeHmacOutput("   \n\t  ");
+		assert.strictEqual(result, "");
+	});
+
+	it("uses lastIndexOf to handle edge case with = in prefix", () => {
+		// Hypothetical edge case: if prefix somehow contains "= "
+		const result = normalizeHmacOutput(`weird= label= ${expectedHash}`);
+		assert.strictEqual(result, expectedHash);
+	});
+});


### PR DESCRIPTION
## Summary

- Extracts `normalizeHmacOutput()` function to handle both OpenSSL and LibreSSL output formats
- macOS LibreSSL outputs just the hex hash (e.g., `6afeb25a...`)
- OpenSSL prefixes output with label (e.g., `SHA2-256(stdin)= 6afeb25a...`)
- Uses `lastIndexOf("= ")` to detect and strip the delimiter, handling both formats cleanly
- Adds comprehensive unit tests (10 test cases) covering both formats and edge cases

## Context

PR #21 removed the broken `awk` command that was failing on macOS. This PR makes the HMAC handling more robust by properly normalizing output from any OpenSSL/LibreSSL version, rather than assuming LibreSSL's output format.

While Alfred only runs on macOS (where LibreSSL is standard), this change improves robustness for:
- Users with custom OpenSSL installations (via Homebrew, MacPorts, etc.)
- Potential edge cases with LibreSSL version differences
- Future-proofing against format changes

## Test Plan

- [x] All existing tests pass (110 total)
- [x] New HMAC normalization tests pass (10 tests)
- [x] CodeRabbit review addressed (nitpick about module extraction is documented as future work in CLAUDE.md)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of cryptographic hash processing across different system configurations.

* **Tests**
  * Added comprehensive test coverage for hash normalization across multiple input formats and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->