### PR TITLE
feat: add Alfred native result caching with toggle (#33)

### DIFF
--- a/tests/build-response.test.js
+++ b/tests/build-response.test.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for buildResponse function
+ * Run with: node tests/build-response.test.js
+ */
+
+const assert = require("node:assert");
+const { describe, it, beforeEach } = require("node:test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+// Extract buildResponse function and CONFIG from search.js
+// We need to create a mock CONFIG that buildResponse references
+const searchJs = fs.readFileSync(
+	path.join(__dirname, "../scripts/search.js"),
+	"utf-8"
+);
+
+// Extract the buildResponse function (matches: cacheSeconds > 0)
+const buildResponseMatch = searchJs.match(
+	/function buildResponse\(items, cacheSeconds\) \{[\s\S]*?cacheSeconds > 0[\s\S]*?return response;\s*\}/
+);
+if (!buildResponseMatch) {
+	throw new Error("Could not find buildResponse function in search.js");
+}
+
+// Create a mock CONFIG that we can manipulate in tests
+let mockConfig = { enableResultCache: true };
+
+// Create buildResponse that uses our mock CONFIG
+const buildResponse = eval(`(function(CONFIG) {
+	return ${buildResponseMatch[0]};
+})(mockConfig)`);
+
+describe("buildResponse", () => {
+	beforeEach(() => {
+		mockConfig.enableResultCache = true;
+	});
+
+	describe("caching enabled", () => {
+		it("includes cache when cacheSeconds provided", () => {
+			const items = [{ title: "test" }];
+			const result = buildResponse(items, 60);
+			assert.deepStrictEqual(result, {
+				items: [{ title: "test" }],
+				cache: {
+					seconds: 60,
+					loosereload: true,
+				},
+			});
+		});
+
+		it("uses loosereload for background refresh", () => {
+			const items = [{ title: "test" }];
+			const result = buildResponse(items, 30);
+			assert.strictEqual(result.cache.loosereload, true);
+		});
+
+		it("respects custom cache duration", () => {
+			const items = [{ title: "test" }];
+			const result = buildResponse(items, 120);
+			assert.strictEqual(result.cache.seconds, 120);
+		});
+	});
+
+	describe("caching disabled via config", () => {
+		beforeEach(() => {
+			mockConfig.enableResultCache = false;
+		});
+
+		it("excludes cache when config disabled", () => {
+			const items = [{ title: "test" }];
+			const result = buildResponse(items, 60);
+			assert.deepStrictEqual(result, {
+				items: [{ title: "test" }],
+			});
+			assert.strictEqual(result.cache, undefined);
+		});
+	});
+
+	describe("no cache seconds provided", () => {
+		it("excludes cache when cacheSeconds is undefined", () => {
+			const items = [{ title: "test" }];
+			const result = buildResponse(items);
+			assert.deepStrictEqual(result, {
+				items: [{ title: "test" }],
+			});
+			assert.strictEqual(result.cache, undefined);
+		});
+
+		it("excludes cache when cacheSeconds is 0", () => {
+			const items = [{ title: "test" }];
+			const result = buildResponse(items, 0);
+			assert.deepStrictEqual(result, {
+				items: [{ title: "test" }],
+			});
+			assert.strictEqual(result.cache, undefined);
+		});
+
+		it("excludes cache when cacheSeconds is null", () => {
+			const items = [{ title: "test" }];
+			const result = buildResponse(items, null);
+			assert.deepStrictEqual(result, {
+				items: [{ title: "test" }],
+			});
+			assert.strictEqual(result.cache, undefined);
+		});
+
+		it("excludes cache when cacheSeconds is negative", () => {
+			const items = [{ title: "test" }];
+			const result = buildResponse(items, -30);
+			assert.deepStrictEqual(result, {
+				items: [{ title: "test" }],
+			});
+			assert.strictEqual(result.cache, undefined);
+		});
+	});
+
+	describe("items passthrough", () => {
+		it("passes through empty items array", () => {
+			const result = buildResponse([], 60);
+			assert.deepStrictEqual(result.items, []);
+		});
+
+		it("passes through multiple items", () => {
+			const items = [
+				{ title: "first" },
+				{ title: "second" },
+				{ title: "third" },
+			];
+			const result = buildResponse(items, 60);
+			assert.deepStrictEqual(result.items, items);
+		});
+
+		it("preserves complex item structure", () => {
+			const items = [{
+				title: "Test Result",
+				subtitle: "example.com",
+				arg: "https://example.com",
+				icon: { path: "icon.png" },
+				mods: {
+					alt: { arg: "alt-action" },
+				},
+			}];
+			const result = buildResponse(items, 60);
+			assert.deepStrictEqual(result.items, items);
+		});
+	});
+});

--- a/tests/parse-bool.test.js
+++ b/tests/parse-bool.test.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for parseBool function
+ * Run with: node tests/parse-bool.test.js
+ */
+
+const assert = require("node:assert");
+const { describe, it } = require("node:test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+// Extract parseBool function from search.js
+const searchJs = fs.readFileSync(
+	path.join(__dirname, "../scripts/search.js"),
+	"utf-8"
+);
+const parseBoolMatch = searchJs.match(
+	/function parseBool\(value, defaultValue = true\) \{[\s\S]*?return lower !== "0" && lower !== "false" && lower !== "no";\s*\}/
+);
+if (!parseBoolMatch) {
+	throw new Error("Could not find parseBool function in search.js");
+}
+// eslint-disable-next-line no-eval
+const parseBool = eval(`(${parseBoolMatch[0]})`);
+
+describe("parseBool", () => {
+	describe("truthy values", () => {
+		it("returns true for '1'", () => {
+			assert.strictEqual(parseBool("1"), true);
+		});
+
+		it("returns true for 'true'", () => {
+			assert.strictEqual(parseBool("true"), true);
+		});
+
+		it("returns true for 'TRUE'", () => {
+			assert.strictEqual(parseBool("TRUE"), true);
+		});
+
+		it("returns true for 'yes'", () => {
+			assert.strictEqual(parseBool("yes"), true);
+		});
+
+		it("returns true for 'YES'", () => {
+			assert.strictEqual(parseBool("YES"), true);
+		});
+
+		it("returns true for any other string", () => {
+			assert.strictEqual(parseBool("enabled"), true);
+		});
+	});
+
+	describe("falsy values", () => {
+		it("returns false for '0'", () => {
+			assert.strictEqual(parseBool("0"), false);
+		});
+
+		it("returns false for 'false'", () => {
+			assert.strictEqual(parseBool("false"), false);
+		});
+
+		it("returns false for 'FALSE'", () => {
+			assert.strictEqual(parseBool("FALSE"), false);
+		});
+
+		it("returns false for 'False'", () => {
+			assert.strictEqual(parseBool("False"), false);
+		});
+
+		it("returns false for 'no'", () => {
+			assert.strictEqual(parseBool("no"), false);
+		});
+
+		it("returns false for 'NO'", () => {
+			assert.strictEqual(parseBool("NO"), false);
+		});
+	});
+
+	describe("empty/undefined values - uses default", () => {
+		it("returns default true for empty string", () => {
+			assert.strictEqual(parseBool(""), true);
+		});
+
+		it("returns default true for null", () => {
+			assert.strictEqual(parseBool(null), true);
+		});
+
+		it("returns default true for undefined", () => {
+			assert.strictEqual(parseBool(undefined), true);
+		});
+
+		it("returns custom default false for empty string", () => {
+			assert.strictEqual(parseBool("", false), false);
+		});
+
+		it("returns custom default false for null", () => {
+			assert.strictEqual(parseBool(null, false), false);
+		});
+
+		it("returns custom default false for undefined", () => {
+			assert.strictEqual(parseBool(undefined, false), false);
+		});
+	});
+
+	describe("case insensitivity", () => {
+		it("handles mixed case 'FaLsE'", () => {
+			assert.strictEqual(parseBool("FaLsE"), false);
+		});
+
+		it("handles mixed case 'No'", () => {
+			assert.strictEqual(parseBool("No"), false);
+		});
+
+		it("handles mixed case 'TrUe'", () => {
+			assert.strictEqual(parseBool("TrUe"), true);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Add configurable result caching using Alfred's native cache feature
- Caching is enabled by default and can be disabled via `enable_result_cache` workflow variable
- Uses `loosereload: true` for optimal UX - cached results show instantly while fresh data loads in background
- Short queries (autocomplete only) cached for 30 seconds
- Full search results cached for 60 seconds

## Changes

- Added `parseBool()` helper for boolean environment variable parsing
- Added `enable_result_cache` to CONFIG
- Added `buildResponse()` helper that conditionally includes cache config
- Refactored all return statements to use `buildResponse()`

## Test plan

- [x] All 142 tests pass
- [x] New `parse-bool.test.js` covers boolean parsing edge cases
- [x] New `build-response.test.js` covers caching behavior
- [ ] Manual test: Repeat same search, verify instant cached response
- [ ] Manual test: Set `enable_result_cache=0`, verify no caching

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced configurable result caching functionality with adjustable cache durations to optimize search performance and enable efficient background refresh behaviour.

* **Tests**
  * Added comprehensive test coverage validating caching configuration options, response generation logic, and various cache duration scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->